### PR TITLE
Fix bento warning

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@ FROM python:3.5-slim
 WORKDIR /servo
 
 # Install dependencies
+# hadolint ignore=DL3013
 RUN pip3 install PyYAML requests signalfx
 RUN apt install -y openjdk-8-jre-headless
 


### PR DESCRIPTION
Bento Output:

```
hadolint DL3013 https://github.com/hadolint/hadolint/wiki/DL3013
     > Dockerfile:6
     ╷
    6│   RUN pip3 install PyYAML requests signalfx
     ╵
     = Pin versions in pip. Instead of `pip install <package>` use `pip install
       <package>==<version>`
```